### PR TITLE
fix: RabbitMQ Authentication and Container Deployment Support

### DIFF
--- a/opentakserver/app.py
+++ b/opentakserver/app.py
@@ -103,7 +103,7 @@ def init_extensions(app):
     socketio_logger = False
     if app.config.get("DEBUG"):
         socketio_logger = logger
-    socketio.init_app(app, logger=socketio_logger, ping_timeout=1, message_queue=f"amqp://{app.config.get('OTS_RABBITMQ_USERNAME')}:{app.config.get('OTS_RABBITMQ_PASSWORD')}@{app.config.get('OTS_RABBITMQ_SERVER_ADDRESS')}/{app.config.get('OTS_RABBITMQ_VHOST')}")
+    socketio.init_app(app, logger=socketio_logger, ping_timeout=1, message_queue=f"amqp://{app.config.get('OTS_RABBITMQ_USERNAME')}:{app.config.get('OTS_RABBITMQ_PASSWORD')}@{app.config.get('OTS_RABBITMQ_SERVER_ADDRESS')}:{app.config.get('OTS_RABBITMQ_PORT', 5672)}/{app.config.get('OTS_RABBITMQ_VHOST')}")
 
     # Debug RabbitMQ configuration
     print(f"DEBUG: RabbitMQ Host: {app.config.get('OTS_RABBITMQ_SERVER_ADDRESS')}")

--- a/opentakserver/blueprints/scheduled_jobs.py
+++ b/opentakserver/blueprints/scheduled_jobs.py
@@ -40,15 +40,30 @@ from opentakserver.functions import iso8601_string_from_datetime, datetime_from_
 scheduler_blueprint = Blueprint('scheduler_blueprint', __name__)
 
 
+def _get_rabbitmq_connection():
+    """Helper function to create RabbitMQ connection with credentials."""
+    rmq_credentials = pika.PlainCredentials(
+        app.config.get("OTS_RABBITMQ_USERNAME", "guest"),
+        app.config.get("OTS_RABBITMQ_PASSWORD", "guest")
+    )
+    rmq_params = pika.ConnectionParameters(
+        host=app.config.get("OTS_RABBITMQ_SERVER_ADDRESS", "localhost"),
+        port=int(app.config.get("OTS_RABBITMQ_PORT", 5672)),
+        virtual_host=app.config.get("OTS_RABBITMQ_VHOST", "/"),
+        credentials=rmq_credentials
+    )
+    return pika.BlockingConnection(rmq_params)
+
+
 def get_airplanes_live_data():
     with apscheduler.app.app_context():
         try:
             r = requests.get('https://api.airplanes.live/v2/point/{}/{}/{}'
-                             .format(app.config["OTS_AIRPLANES_LIVE_LAT"],
-                                     app.config["OTS_AIRPLANES_LIVE_LON"],
-                                     app.config["OTS_AIRPLANES_LIVE_RADIUS"]))
+                            .format(app.config["OTS_AIRPLANES_LIVE_LAT"],
+                                    app.config["OTS_AIRPLANES_LIVE_LON"],
+                                    app.config["OTS_AIRPLANES_LIVE_RADIUS"]))
             if r.status_code == 200:
-                rabbit_connection = pika.BlockingConnection(pika.ConnectionParameters(app.config.get("OTS_RABBITMQ_SERVER_ADDRESS")))
+                rabbit_connection = _get_rabbitmq_connection()
                 channel = rabbit_connection.channel()
 
                 for craft in r.json()['ac']:
@@ -60,11 +75,11 @@ def get_airplanes_live_data():
                     # noinspection PyTypeChecker
                     channel.basic_publish(exchange='cot', routing_key='', body=json.dumps(
                         {'cot': str(BeautifulSoup(event, 'xml')), 'uid': app.config['OTS_NODE_ID']}),
-                                          properties=pika.BasicProperties(expiration=app.config.get("OTS_RABBITMQ_TTL")))
+                        properties=pika.BasicProperties(expiration=app.config.get("OTS_RABBITMQ_TTL")))
                     # noinspection PyTypeChecker
                     channel.basic_publish(exchange='cot_controller', routing_key='', body=json.dumps(
                         {'cot': str(BeautifulSoup(event, 'xml')), 'uid': app.config['OTS_NODE_ID']}),
-                                          properties=pika.BasicProperties(expiration=app.config.get("OTS_RABBITMQ_TTL")))
+                        properties=pika.BasicProperties(expiration=app.config.get("OTS_RABBITMQ_TTL")))
 
                 channel.close()
                 rabbit_connection.close()
@@ -87,7 +102,7 @@ def delete_video_recordings():
                 for path in recordings['items']:
                     for recording in path['segments']:
                         r = requests.delete('{}/v3/recordings/deletesegment'.format(app.config.get("OTS_MEDIAMTX_API_ADDRESS"),),
-                                            params={'start': recording['start'], 'path': path['name']})
+                                          params={'start': recording['start'], 'path': path['name']})
                         if r.status_code != 200:
                             logger.error(
                                 "Failed to delete {} from {}: {}".format(recording['start'], path['name'], r.text))
@@ -148,18 +163,19 @@ def get_aishub_data():
                 logger.error(f"Failed to get AIS data: {r.text}")
                 return
 
-            rabbit_connection = pika.BlockingConnection(pika.ConnectionParameters(app.config.get("OTS_RABBITMQ_SERVER_ADDRESS")))
+            rabbit_connection = _get_rabbitmq_connection()
             channel = rabbit_connection.channel()
+
             for vessel in r.json()[1]:
                 event = aiscot.ais_to_cot(vessel, None, None)
                 # noinspection PyTypeChecker
                 channel.basic_publish(exchange='cot', routing_key='', body=json.dumps(
                     {'cot': str(BeautifulSoup(event, 'xml')), 'uid': app.config['OTS_NODE_ID']}),
-                                      properties=pika.BasicProperties(expiration=app.config.get("OTS_RABBITMQ_TTL")))
+                    properties=pika.BasicProperties(expiration=app.config.get("OTS_RABBITMQ_TTL")))
                 # noinspection PyTypeChecker
                 channel.basic_publish(exchange='cot_controller', routing_key='', body=json.dumps(
                     {'cot': str(BeautifulSoup(event, 'xml')), 'uid': app.config['OTS_NODE_ID']}),
-                                      properties=pika.BasicProperties(expiration=app.config.get("OTS_RABBITMQ_TTL")))
+                    properties=pika.BasicProperties(expiration=app.config.get("OTS_RABBITMQ_TTL")))
 
             channel.close()
             rabbit_connection.close()
@@ -176,8 +192,7 @@ def delete_old_data():
         days=app.config.get("OTS_DELETE_OLD_DATA_DAYS"),
         weeks=app.config.get("OTS_DELETE_OLD_DATA_WEEKS"))
 
-    rabbit_connection = pika.BlockingConnection(
-        pika.ConnectionParameters(app.config.get("OTS_RABBITMQ_SERVER_ADDRESS")))
+    rabbit_connection = _get_rabbitmq_connection()
     channel = rabbit_connection.channel()
 
     # I wish I hadn't made the marker's timestamp field a string...
@@ -188,7 +203,7 @@ def delete_old_data():
             cot = generate_delete_cot(marker.uid, marker.cot.type)
             channel.basic_publish(exchange='cot', routing_key='', body=json.dumps(
                 {'cot': tostring(cot).decode('utf-8'), 'uid': app.config['OTS_NODE_ID']}),
-                                  properties=pika.BasicProperties(expiration=app.config.get("OTS_RABBITMQ_TTL")))
+                properties=pika.BasicProperties(expiration=app.config.get("OTS_RABBITMQ_TTL")))
             db.session.delete(marker)
 
     alerts = db.session.execute(db.session.query(Alert).where(Alert.start_time <= timestamp)).all()

--- a/opentakserver/controllers/rabbitmq_client.py
+++ b/opentakserver/controllers/rabbitmq_client.py
@@ -21,7 +21,18 @@ class RabbitMQClient:
         self.exchanges = []
 
         try:
-            self.rabbit_connection = pika.SelectConnection(pika.ConnectionParameters(self.context.app.config.get("OTS_RABBITMQ_SERVER_ADDRESS")),
+            # Build pika connection parameters with credentials
+            rmq_credentials = pika.PlainCredentials(
+                self.context.app.config.get("OTS_RABBITMQ_USERNAME", "guest"),
+                self.context.app.config.get("OTS_RABBITMQ_PASSWORD", "guest")
+            )
+            rmq_params = pika.ConnectionParameters(
+                host=self.context.app.config.get("OTS_RABBITMQ_SERVER_ADDRESS", "localhost"),
+                port=int(self.context.app.config.get("OTS_RABBITMQ_PORT", 5672)),
+                virtual_host=self.context.app.config.get("OTS_RABBITMQ_VHOST", "/"),
+                credentials=rmq_credentials
+            )
+            self.rabbit_connection = pika.SelectConnection(rmq_params,
                                                            self.on_connection_open)
             self.rabbit_channel: Channel = None
             self.iothread = Thread(target=self.rabbit_connection.ioloop.start)

--- a/opentakserver/cot_parser/cot_parser.py
+++ b/opentakserver/cot_parser/cot_parser.py
@@ -76,13 +76,24 @@ class CoTController:
         self.rabbit_channel = None
 
     def run(self):
-        self.rabbit_connection = pika.BlockingConnection(
-            pika.ConnectionParameters(self.context.app.config.get("OTS_RABBITMQ_SERVER_ADDRESS")))
+        # Build pika connection parameters with credentials
+        rmq_credentials = pika.PlainCredentials(
+            self.context.app.config.get("OTS_RABBITMQ_USERNAME", "guest"),
+            self.context.app.config.get("OTS_RABBITMQ_PASSWORD", "guest")
+        )
+        rmq_params = pika.ConnectionParameters(
+            host=self.context.app.config.get("OTS_RABBITMQ_SERVER_ADDRESS", "localhost"),
+            port=int(self.context.app.config.get("OTS_RABBITMQ_PORT", 5672)),
+            virtual_host=self.context.app.config.get("OTS_RABBITMQ_VHOST", "/"),
+            credentials=rmq_credentials
+        )
+        self.rabbit_connection = pika.BlockingConnection(rmq_params)
         self.rabbit_channel = self.rabbit_connection.channel()
         self.rabbit_channel.queue_declare(queue='cot_controller')
         self.rabbit_channel.exchange_declare(exchange='cot_controller', exchange_type='fanout')
         self.rabbit_channel.queue_bind(exchange='cot_controller', queue='cot_controller')
-        self.rabbit_channel.basic_qos(prefetch_count=self.context.app.config.get("OTS_RABBITMQ_PREFETCH"))
+        prefetch_count = self.context.app.config.get("OTS_RABBITMQ_PREFETCH", 2)
+        self.rabbit_channel.basic_qos(prefetch_count=int(prefetch_count))
         self.rabbit_channel.basic_consume(queue='cot_controller', on_message_callback=self.on_message, auto_ack=False)
         self.rabbit_channel.start_consuming()
 
@@ -953,6 +964,11 @@ def create_app():
                     conf[option] = DefaultConfig.__dict__[option]
             config.write(yaml.safe_dump(conf))
 
+    # Load environment variables into Flask config AFTER config.yml
+    for key, value in os.environ.items():
+        if key.startswith("OTS_") or key in ["POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_DB", "POSTGRES_USER", "POSTGRES_PASSWORD", "DATABASE_URL", "SQLALCHEMY_DATABASE_URI"]:
+            app.config[key] = value
+
     setup_logging(app)
     db.init_app(app)
 
@@ -974,30 +990,46 @@ child_processes = []
 
 
 def main():
-    sio = SocketIO(message_queue="amqp://" + app.config.get("OTS_RABBITMQ_SERVER_ADDRESS"))
+    # Build RabbitMQ URL with credentials for SocketIO
+    rmq_user = app.config.get("OTS_RABBITMQ_USERNAME", "guest")
+    rmq_pass = app.config.get("OTS_RABBITMQ_PASSWORD", "guest")
+    rmq_host = app.config.get("OTS_RABBITMQ_SERVER_ADDRESS", "localhost")
+    rmq_port = app.config.get("OTS_RABBITMQ_PORT", 5672)
+    rmq_vhost = app.config.get("OTS_RABBITMQ_VHOST", "/")
+    rmq_url = f"amqp://{rmq_user}:{rmq_pass}@{rmq_host}:{rmq_port}/{rmq_vhost}"
+    sio = SocketIO(message_queue=rmq_url)
 
-    processes = 0
-    while processes < app.config.get("OTS_COT_PARSER_PROCESSES"):
-        try:
-            pid = os.fork()
-            if pid == 0:
-                cot_parser = CoTController(app.app_context(), logger, db, sio)
-                cot_parser.run()
-            else:
-                child_processes.append(pid)
-        except KeyboardInterrupt:
-            pass
-        except BaseException as e:
-            logger.error(f"cot_parser error: {e}")
-            logger.debug(traceback.format_exc())
-        processes += 1
+    num_processes = int(app.config.get("OTS_COT_PARSER_PROCESSES", 1))
+    
+    # If only 1 process, run directly without forking to avoid deadlock issues
+    if num_processes == 1:
+        logger.info("Starting CoT parser (single process mode)")
+        cot_parser = CoTController(app.app_context(), logger, db, sio)
+        cot_parser.run()
+    else:
+        # Multi-process mode with forking
+        processes = 0
+        while processes < num_processes:
+            try:
+                pid = os.fork()
+                if pid == 0:
+                    cot_parser = CoTController(app.app_context(), logger, db, sio)
+                    cot_parser.run()
+                else:
+                    child_processes.append(pid)
+            except KeyboardInterrupt:
+                pass
+            except BaseException as e:
+                logger.error(f"cot_parser error: {e}")
+                logger.debug(traceback.format_exc())
+            processes += 1
 
-    for i, child in enumerate(child_processes):
-        try:
-            os.waitpid(child, 0)
-        except BaseException:
-            logger.info(f"Exiting...")
-            sys.exit()
+        for i, child in enumerate(child_processes):
+            try:
+                os.waitpid(child, 0)
+            except BaseException:
+                logger.info(f"Exiting...")
+                sys.exit()
 
 
 if __name__ == "__main__":

--- a/opentakserver/eud_handler/SocketServer.py
+++ b/opentakserver/eud_handler/SocketServer.py
@@ -101,7 +101,7 @@ class SocketServer:
                 os.path.join(self.app_context.app.config.get("OTS_CA_FOLDER"), "certs", "opentakserver", "opentakserver.pem"),
                 os.path.join(self.app_context.app.config.get("OTS_CA_FOLDER"), "certs", "opentakserver", "opentakserver.nopass.key"))
 
-            context.verify_mode = self.app_context.app.config.get("OTS_SSL_VERIFICATION_MODE")
+            context.verify_mode = int(self.app_context.app.config.get("OTS_SSL_VERIFICATION_MODE"))
             context.load_verify_locations(cafile=os.path.join(self.app_context.app.config.get("OTS_CA_FOLDER"), 'ca.pem'))
 
             return context

--- a/opentakserver/eud_handler/client_controller.py
+++ b/opentakserver/eud_handler/client_controller.py
@@ -44,7 +44,14 @@ class ClientController(Thread):
         self.app = app
         self.db = db
         self.is_ssl = is_ssl
-        self.socketio = SocketIO(message_queue="amqp://" + app.config.get("OTS_RABBITMQ_SERVER_ADDRESS"))
+        # Build RabbitMQ URL with credentials for SocketIO
+        rmq_user = app.config.get("OTS_RABBITMQ_USERNAME", "guest")
+        rmq_pass = app.config.get("OTS_RABBITMQ_PASSWORD", "guest")
+        rmq_host = app.config.get("OTS_RABBITMQ_SERVER_ADDRESS", "localhost")
+        rmq_port = app.config.get("OTS_RABBITMQ_PORT", 5672)
+        rmq_vhost = app.config.get("OTS_RABBITMQ_VHOST", "/")
+        rmq_url = f"amqp://{rmq_user}:{rmq_pass}@{rmq_host}:{rmq_port}/{rmq_vhost}"
+        self.socketio = SocketIO(message_queue=rmq_url)
 
         self.user = None
 
@@ -86,7 +93,18 @@ class ClientController(Thread):
 
         # RabbitMQ
         try:
-            self.rabbit_connection = pika.SelectConnection(pika.ConnectionParameters(self.app.config.get("OTS_RABBITMQ_SERVER_ADDRESS")),
+            # Build pika connection parameters with credentials
+            rmq_credentials = pika.PlainCredentials(
+                self.app.config.get("OTS_RABBITMQ_USERNAME", "guest"),
+                self.app.config.get("OTS_RABBITMQ_PASSWORD", "guest")
+            )
+            rmq_params = pika.ConnectionParameters(
+                host=self.app.config.get("OTS_RABBITMQ_SERVER_ADDRESS", "localhost"),
+                port=int(self.app.config.get("OTS_RABBITMQ_PORT", 5672)),
+                virtual_host=self.app.config.get("OTS_RABBITMQ_VHOST", "/"),
+                credentials=rmq_credentials
+            )
+            self.rabbit_connection = pika.SelectConnection(rmq_params,
                                                            self.on_connection_open)
             self.rabbit_channel: Channel | None = None
             # Start the pika ioloop in a thread or else it blocks and we can't receive any CoT messages

--- a/opentakserver/eud_handler/eud_handler.py
+++ b/opentakserver/eud_handler/eud_handler.py
@@ -96,6 +96,12 @@ def create_app():
                     conf[option] = DefaultConfig.__dict__[option]
             config.write(yaml.safe_dump(conf))
 
+    # Load environment variables into Flask config AFTER config.yml
+    # This allows env vars to override config.yml values
+    for key, value in os.environ.items():
+        if key.startswith("OTS_") or key in ["POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_DB", "POSTGRES_USER", "POSTGRES_PASSWORD", "DATABASE_URL", "SQLALCHEMY_DATABASE_URI"]:
+            app.config[key] = value
+
     setup_logging(app)
     db.init_app(app)
 
@@ -121,10 +127,10 @@ app = create_app()
 def main():
     opts = args()
     if opts.ssl:
-        socket_server = SocketServer(logger, app.app_context(), app.config.get("OTS_SSL_STREAMING_PORT"), True)
+        socket_server = SocketServer(logger, app.app_context(), int(app.config.get("OTS_SSL_STREAMING_PORT")), True)
         logger.info(f"Started SSL server on port {app.config.get('OTS_SSL_STREAMING_PORT')}")
     else:
-        socket_server = SocketServer(logger, app.app_context(), app.config.get("OTS_TCP_STREAMING_PORT"))
+        socket_server = SocketServer(logger, app.app_context(), int(app.config.get("OTS_TCP_STREAMING_PORT")))
         logger.info(f"Started TCP server on port {app.config.get('OTS_TCP_STREAMING_PORT')}")
     socket_server.run()
 


### PR DESCRIPTION
## Problem

The EUD handler and CoT parser do not support authenticated RabbitMQ connections, which is required for production containerized deployments where RabbitMQ is secured with username/password authentication.

Additionally, environment variables are loaded before config.yml, preventing Docker deployments from overriding configuration values.

## Solution

This PR adds comprehensive container deployment support:

### 1. RabbitMQ Authentication Support
- Added support for `OTS_RABBITMQ_USERNAME`, `OTS_RABBITMQ_PASSWORD`, `OTS_RABBITMQ_VHOST`, and `OTS_RABBITMQ_PORT` configuration options
- Use `pika.PlainCredentials` and `ConnectionParameters` instead of simple host strings
- Build proper AMQP URLs with credentials for SocketIO message queue

### 2. Environment Variable Override
- Load environment variables AFTER config.yml in both `eud_handler.py` and `cot_parser.py`
- This allows Docker/container deployments to override config values via environment variables

### 3. Type Conversion Fixes
- Added `int()` conversion for `OTS_SSL_VERIFICATION_MODE` in SocketServer.py
- Added `int()` conversion for `OTS_RABBITMQ_PREFETCH` with default value of 2
- Added `int()` conversion for `OTS_COT_PARSER_PROCESSES`

### 4. Single-Process Mode for CoT Parser
- When `OTS_COT_PARSER_PROCESSES=1`, run directly without forking
- Avoids `os.fork()` deadlocks in multi-threaded containerized environments
- Multi-process mode still available when processes > 1

## Files Changed
- `opentakserver/eud_handler/client_controller.py` - RabbitMQ auth support
- `opentakserver/eud_handler/eud_handler.py` - Env var override support
- `opentakserver/eud_handler/SocketServer.py` - SSL mode type conversion
- `opentakserver/cot_parser/cot_parser.py` - All fixes combined

## Testing

1. Deploy with Docker Compose using secured RabbitMQ:
   - Set `OTS_RABBITMQ_USERNAME`, `OTS_RABBITMQ_PASSWORD`, `OTS_RABBITMQ_VHOST`
2. Verify EUD handler connects to RabbitMQ
3. Verify CoT parser consumes from `cot_controller` queue
4. Test ATAK client connection and message routing
5. Verify WebTAK receives position updates via SocketIO

## Related Issues

Fixes container deployment issues where:
- RabbitMQ authentication fails with "ACCESS_REFUSED"
- Environment variables don't override config.yml
- CoT parser deadlocks on startup due to fork() issues